### PR TITLE
Move code to files, fix windows and other bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.7'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/src/VersionBenchmarks.jl
+++ b/src/VersionBenchmarks.jl
@@ -70,7 +70,7 @@ function benchmark(configs::Vector{Config}, files::AbstractVector{String};
 
                 for file in files
                     time_of_run = now()
-                    
+
                     print("   Executing \"$file\"...")
                     t = time()
                     resultdf = execute_file(file, julia_cmd, tmpenvdir, repetition)
@@ -107,36 +107,19 @@ end
 get_julia_version(julia_cmd) = read(`$julia_cmd --startup-file=no -e 'print(VERSION)'`, String)
 
 function prepare_julia_environment(config, tmpdir_dict)
+    prepare_jl = joinpath(@__DIR__, "prepare_env.jl")
+    print("   Preparing Julia environment...")
+    t = time()
     if haskey(tmpdir_dict, config)
         tmpenvdir = tmpdir_dict[config]
-
-        code = """
-        "@stdlib" ∉ LOAD_PATH && push!(LOAD_PATH, "@stdlib")
-        using Pkg
-        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true # avoid updating every time
-        Pkg.activate("$tmpenvdir")
-        Pkg.precompile()
-        """
     else
         # create a directory for the environment in which to install the version
         tmpenvdir = mktempdir()
         tmpdir_dict[config] = tmpenvdir
-
         specs = [config.pkgspecs; (;name = "BenchmarkTools")]
         specstring = string(specs) # TODO: other way to transfer package specs to the new process?
-
-        code = """
-        "@stdlib" ∉ LOAD_PATH && push!(LOAD_PATH, "@stdlib")
-        using Pkg
-        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true # avoid updating every time
-        Pkg.activate("$tmpenvdir")
-        Pkg.add($specstring; $(hide_output[] ? "io = devnull, " : ""))
-        Pkg.precompile()
-        """
+        _run(`$(config.julia) --project=$tmpenvdir --startup-file=no $prepare_jl  $(hide_output[]) $specstring`)
     end
-    print("   Preparing Julia environment...")
-    t = time()
-    _run(`$(config.julia) --startup-file=no -e $code`)
     println(" Done. ($(round(Int, time() - t))s)")
     return tmpenvdir
 end
@@ -144,19 +127,15 @@ end
 function execute_file(file, julia_cmd, tmpenvdir, repetition)
     resultpath, resultio = mktemp()
 
-    basecode = get_basecode(tmpenvdir, resultpath, repetition)
-
-    testcode = read(file, String)
-
-    fullcode = join([basecode, testcode], "\n")
-
     path, io = mktemp()
-    open(path, "w") do file
-        println(file, fullcode)
+    open(path, "w") do code_io
+        open(io-> write(code_io, io), joinpath(@__DIR__, "execute_bench.jl"))
+        println(code_io)
+        open(io-> write(code_io, io), file)
     end
 
     # execute the modified code, this should write results to the temp file at `resultpath`
-    _run(`$julia_cmd --startup-file=no $path`)
+    _run(`$julia_cmd --project=$tmpenvdir --startup-file=no $path $resultpath $repetition`)
 
     results = foldl(((a, b) -> push!(a, b, cols = :union)),
         map(parse_result_line, readlines(resultpath)),
@@ -167,49 +146,6 @@ end
 function parse_result_line(line)
     # the file should only have lines with serialized NamedTuples
     lineresult = Dict(pairs(eval(Meta.parse(line))))
-end
-
-function get_basecode(tmpenvdir, resultpath, repetition)
-    """
-    "@stdlib" ∉ LOAD_PATH && push!(LOAD_PATH, "@stdlib")
-    using Pkg
-    Pkg.activate("$tmpenvdir")
-    import BenchmarkTools
-    import Statistics
-
-    macro vbtime(name, expr)
-        @assert name isa String
-        quote
-            io = open("$resultpath", "a")
-            @timed 1 + 1
-            tstart = time_ns()
-            timed = @timed(\$(esc(expr)))
-            dt = (time_ns() - tstart) / 1_000_000_000
-            println(io, (type = "vbtime", name = \$name, time_s = dt, alloc_bytes = timed.bytes, gctime_s = timed.gctime))
-            close(io)
-        end
-    end
-
-    macro vbbenchmark(name, exprs...)
-        @assert name isa String
-        quote
-            # only run vbbenchmark on first repetition
-            if $repetition == 1
-                io = open("$resultpath", "a")
-                bm = BenchmarkTools.@benchmark \$(exprs...)
-                println(io, (
-                    type = "vbbenchmark", 
-                    name = \$name,
-                    min_time_ns = minimum(bm.times),
-                    max_time_ns = maximum(bm.times),
-                    median_time_ns = Statistics.median(bm.times),
-                    mean_time_ns = Statistics.mean(bm.times),
-                ))
-                close(io)
-            end
-        end
-    end
-"""
 end
 
 function summarize_repetitions(df)

--- a/src/execute_bench.jl
+++ b/src/execute_bench.jl
@@ -1,0 +1,41 @@
+resultpath, _repetition = ARGS
+repetition = parse(Int, _repetition)
+import BenchmarkTools
+import Statistics
+
+macro vbtime(name, expr)
+    @assert name isa String
+    quote
+        io = open(resultpath, "a")
+        gc_stats = Base.gc_num()
+        tstart = time_ns()
+        timed = $(esc(expr))
+        dt = (time_ns() - tstart) / 1e9
+        gc_diff = Base.GC_Diff(Base.gc_num(), gc_stats)
+        println(io, (
+            type = "vbtime", name = $name, time_s = dt,
+            alloc_bytes = gc_diff.allocd,
+            gctime_s = gc_diff.total_time /  1e9))
+        close(io)
+    end
+end
+
+macro vbbenchmark(name, exprs...)
+    @assert name isa String
+    quote
+        # only run vbbenchmark on first repetition
+        if $repetition == 1
+            io = open("$resultpath", "a")
+            bm = BenchmarkTools.@benchmark $(exprs...)
+            println(io, (
+                type = "vbbenchmark",
+                name = $name,
+                min_time_ns = minimum(bm.times),
+                max_time_ns = maximum(bm.times),
+                median_time_ns = Statistics.median(bm.times),
+                mean_time_ns = Statistics.mean(bm.times),
+            ))
+            close(io)
+        end
+    end
+end

--- a/src/prepare_env.jl
+++ b/src/prepare_env.jl
@@ -1,0 +1,7 @@
+_hide_output, specstring = ARGS
+hide_output = parse(Bool, _hide_output)
+using Pkg
+Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true # avoid updating every time
+packages = eval(Meta.parse(specstring))
+Pkg.add(packages; io = hide_output ? devnull : stdout)
+Pkg.instantiate()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,26 @@
 using VersionBenchmarks
 using Test
+
+VersionBenchmarks.hide_output[] = false
+
+versions = [
+    Config("master", [(name="Colors", rev="master")]),
+    Config("0.12.7", [(name="Colors", version="0.12.7")]),
+    Config("0.12.0", [(name="Colors", version="0.12.0")]),
+    Config("0.10.2", [(name="Colors", version="0.10.2")]),
+]
+
+dataframe = benchmark(
+    versions,
+    joinpath(@__DIR__, "test.jl"),
+    repetitions = 5,
+)
+
+@testset "most basic tests" begin
+    @test length(dataframe.time_s) == 40
+    @test length(names(dataframe)) == 13
+    @test all(x-> x > 0.01, dataframe.time_s)
+
+    figure_grid = VersionBenchmarks.plot_summary(dataframe)
+    @test figure_grid isa VersionBenchmarks.AoG.FigureGrid
+end

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,7 +1,12 @@
-@vbtime "using TestRepo" begin
-    using TestRepo
+@vbtime "using Colors" begin
+    using Colors
 end
 
-@vbtime "Heavy computation" begin
-    TestRepo.heavy_computation()
+function rgbatuple(c::Colorant)
+    rgba = RGBA(c)
+    return (red(rgba), green(rgba), blue(rgba), alpha(rgba))
+end
+
+@vbtime "Call function" begin
+    rgbatuple(HSV(0.1, 0.2, 0.3))
 end


### PR DESCRIPTION
- [x] moves executed code snippets into files, which is easier to read, and avoids that on windows interpolating paths into the source in a cmd object doesn't escape correctly.
- [x] removes `@timed`, which inserts a `Expr(:meta, :force_compile)` which messes benchmarking compilation overhead.
- [x] adds simple tests
- [ ] removes `Pkg.precompile()` to be called before every benchmark. I did that because sometimes compilation just gets forced by that. I think maybe we should just set up all envs and precompile them in one go. This way one also gets errors with the envs, before lots of time is already spent on benchmarking
- [ ] move macros into small module, which then can be called via using in the benchmark scripts. This way linting + executing the file standalone works better, and we don't need to write out a new file with the macros spliced in